### PR TITLE
update namecase based on recent changes by others.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,3 +1,4 @@
+Gemfile
 History.txt
 LICENSE.txt
 Manifest.txt

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,6 @@ require 'rubygems'
 require 'hoe'
 require './lib/namecase.rb'
 
-Hoe.new('namecase', NameCase::VERSION) do |p|
+Hoe.spec('namecase') do |p|
   p.developer('Aaron Patterson', 'aaronp@rubyforge.org')
 end

--- a/lib/namecase.rb
+++ b/lib/namecase.rb
@@ -3,7 +3,7 @@ module NameCase
 
   # Returns a new +String+ with the contents properly namecased
   def nc(options = {})
-    options = { :lazy => true, :irish => false }.merge options
+    options = { :lazy => true, :irish => true }.merge options
 
     # Skip if string is mixed case
     if options[:lazy]

--- a/namecase.gemspec
+++ b/namecase.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_development_dependency "hoe"
 end

--- a/test/test_namecase.rb
+++ b/test/test_namecase.rb
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 $:.unshift File.join(File.dirname(__FILE__), "..", "lib")
 $:.unshift File.join(File.dirname(__FILE__), "..", "test")
 
@@ -31,17 +33,18 @@ class TestNameCase < Test::Unit::TestCase
 
   def test_namecase
     @proper_names.each do |name|
-      nc_name = NameCase.new(name)
-      assert_equal(name, nc_name.downcase.nc)
-      assert_equal(name, NameCase.nc(name))
+      assert_equal(name, NameCase(name.downcase))
+      n = name.dup
+      n.extend(NameCase)
+      assert_equal(name, n.nc)
       assert_equal(name, NameCase(name))
     end
   end
 
   def test_namecase_modify
     @proper_names.each do |name|
-      nc_name = NameCase.new(name)
-      assert_equal(name, nc_name.downcase.nc!)
+      nc_name = NameCase!(name.downcase)
+      assert_equal(name, nc_name)
     end
   end
 
@@ -49,7 +52,7 @@ class TestNameCase < Test::Unit::TestCase
     $KCODE = 'u'
 
     proper_cased = 'Iñtërnâtiônàlizætiøn'
-    nc_name = NameCase.new(proper_cased)
-    assert_equal(proper_cased, nc_name.downcase.nc)
+    nc_name = NameCase(proper_cased.downcase)
+    assert_equal(proper_cased, nc_name)
   end
 end


### PR DESCRIPTION
- Namecase is now a module.  ( danxexe )
- add Brazilian exceptions ( danxexe )
- additional Irish exceptions ( robotmay )
- use latest Hoe interface (s/Hoe.new/Hoe.spec/ )  (mustmodify)
