### PR TITLE
Add new entry of "son (daughter) of" (Arabic: bin, binti, binte).

### DIFF
--- a/lib/namecase.rb
+++ b/lib/namecase.rb
@@ -55,6 +55,7 @@ module NameCase
 
     # Fixes for "son (daughter) of" etc
     localstring.gsub!(/\bAl(?=\s+\w)/, 'al')  # al Arabic or forename Al.
+    localstring.gsub!(/\b(Bin|Binti|Binte)\b/,'bin')  # bin, binti, binte Arabic
     localstring.gsub!(/\bAp\b/, 'ap')         # ap Welsh.
     localstring.gsub!(/\bBen(?=\s+\w)/,'ben') # ben Hebrew or forename Ben.
     localstring.gsub!(/\bDell([ae])\b/,'dell\1')  # della and delle Italian.

--- a/test/test_namecase.rb
+++ b/test/test_namecase.rb
@@ -24,7 +24,7 @@ class TestNameCase < Minitest::Test
       "Maciulis",         "Macias",               "MacMurdo",
       # Roman numerals
       "Henry VIII",       "Louis III",            "Louis XIV",
-      "Charles II",       "Fred XLIX",
+      "Charles II",       "Fred XLIX",            "Yusof bin Ishak",
     ]
   end
 


### PR DESCRIPTION
I was reading the wiki entry of "Yusof bin Ishak", Singapore's first president.

Ref. http://en.wikipedia.org/wiki/Yusof_bin_Ishak

Yusof bin Ishak

> This is a Malay name; the name Ishak is a patronymic, not a family name, and the person should be referred to by the given name, Yusof. The Arabic word "bin" ("b.") or "binti"/"binte" ("bt."/"bte."), if used, means "son of" or "daughter of" respectively.

:smile: 


```
$ rake
/Users/Juan/.rubies/ruby-2.2.0/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; require "minitest/autorun"; require "test/test_namecase.rb"' --
Run options: --seed 8004

# Running:

...

Finished in 0.009324s, 321.7503 runs/s, 18983.2690 assertions/s.

3 runs, 177 assertions, 0 failures, 0 errors, 0 skips
```