### PR TITLE
Add option to skip "son (daughter) of" formatting

### DIFF
--- a/lib/namecase.rb
+++ b/lib/namecase.rb
@@ -16,7 +16,10 @@ module NameCase
   end
 
   def self.nc str, options = {}
-    options = { :lazy => true, :irish => true, :spanish => true }.merge options
+    options = { :lazy => true,
+                :irish => true,
+                :spanish => true,
+                :son_or_daughter_of => true }.merge options
 
     # Skip if string is mixed case
     if options[:lazy]
@@ -53,20 +56,23 @@ module NameCase
       localstring.gsub!('Macmurdo','MacMurdo')
     end
 
-    # Fixes for "son (daughter) of" etc
-    localstring.gsub!(/\bAl(?=\s+\w)/, 'al')  # al Arabic or forename Al.
-    localstring.gsub!(/\b(Bin|Binti|Binte)\b/,'bin')  # bin, binti, binte Arabic
-    localstring.gsub!(/\bAp\b/, 'ap')         # ap Welsh.
-    localstring.gsub!(/\bBen(?=\s+\w)/,'ben') # ben Hebrew or forename Ben.
-    localstring.gsub!(/\bDell([ae])\b/,'dell\1')  # della and delle Italian.
-    localstring.gsub!(/\bD([aeiou])\b/,'d\1')   # da, de, di Italian; du French; do Brasil
-    localstring.gsub!(/\bD([ao]s)\b/,'d\1')   # das, dos Brasileiros
-    localstring.gsub!(/\bDe([lr])\b/,'de\1')   # del Italian; der Dutch/Flemish.
-    localstring.gsub!(/\bEl\b/,'el')   # el Greek or El Spanish.
-    localstring.gsub!(/\bLa\b/,'la')   # la French or La Spanish.
-    localstring.gsub!(/\bL([eo])\b/,'l\1')      # lo Italian; le French.
-    localstring.gsub!(/\bVan(?=\s+\w)/,'van')  # van German or forename Van.
-    localstring.gsub!(/\bVon\b/,'von')  # von Dutch/Flemish
+
+    if options[:son_or_daughter_of]
+      # Fixes for "son (daughter) of" etc
+      localstring.gsub!(/\bAl(?=\s+\w)/, 'al')  # al Arabic or forename Al.
+      localstring.gsub!(/\b(Bin|Binti|Binte)\b/,'bin')  # bin, binti, binte Arabic
+      localstring.gsub!(/\bAp\b/, 'ap')         # ap Welsh.
+      localstring.gsub!(/\bBen(?=\s+\w)/,'ben') # ben Hebrew or forename Ben.
+      localstring.gsub!(/\bDell([ae])\b/,'dell\1')  # della and delle Italian.
+      localstring.gsub!(/\bD([aeiou])\b/,'d\1')   # da, de, di Italian; du French; do Brasil
+      localstring.gsub!(/\bD([ao]s)\b/,'d\1')   # das, dos Brasileiros
+      localstring.gsub!(/\bDe([lr])\b/,'de\1')   # del Italian; der Dutch/Flemish.
+      localstring.gsub!(/\bEl\b/,'el')   # el Greek or El Spanish.
+      localstring.gsub!(/\bLa\b/,'la')   # la French or La Spanish.
+      localstring.gsub!(/\bL([eo])\b/,'l\1')      # lo Italian; le French.
+      localstring.gsub!(/\bVan(?=\s+\w)/,'van')  # van German or forename Van.
+      localstring.gsub!(/\bVon\b/,'von')  # von Dutch/Flemish
+    end
 
     # Fix roman numeral names
     localstring.gsub!(

--- a/test/test_namecase.rb
+++ b/test/test_namecase.rb
@@ -51,4 +51,13 @@ class TestNameCase < Minitest::Test
     nc_name = NameCase(proper_cased.downcase)
     assert_equal(proper_cased, nc_name)
   end
+
+  def test_that_it_skips_son_or_daughter_of_formatting
+    names = ["De Shawn", "Da'Quan", "Le'Andre", "La Tonya"]
+
+    names.each do |name|
+      nc_name = NameCase(name.downcase, son_or_daughter_of: false)
+      assert_equal(name, nc_name)
+    end
+  end
 end


### PR DESCRIPTION
A lot of my users' names are not formatted properly because of the "son (daughter) of" formatting. I added an option so that it's possible to ignore that section of formatting, along with some test cases.