### PR TITLE
Two Trivial Fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,12 @@ Hoe.plugin :doofus, :git, :gemspec
 Hoe.spec('namecase') do |p|
   self.readme_file       = 'README.md'
   developer('Aaron Patterson', 'aaronp@rubyforge.org')
+  self.urls = {
+    "home" => "https://rubygems.org/gems/namecase",
+    "code" => "https://github.com/tenderlove/namecase",
+    "bugs" => "https://github.com/tenderlove/namecase/issues",
+  }
+
   license   'GPL'
   extra_dev_deps << ['minitest', '~> 4.0']
 end

--- a/namecase.gemspec
+++ b/namecase.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = ["aaronp@rubyforge.org"]
   s.extra_rdoc_files = ["History.txt", "LICENSE.txt", "Manifest.txt", "README.md"]
   s.files = [".gemtest", "Gemfile", "History.txt", "LICENSE.txt", "Manifest.txt", "README.md", "Rakefile", "lib/namecase.rb", "test/test_namecase.rb"]
-  s.homepage = "http://namecase.rubyforge.org/"
+  s.homepage = "https://rubygems.org/gems/namecase"
   s.licenses = ["GPL"]
   s.rdoc_options = ["--main", "README.md"]
   s.rubygems_version = "2.4.5"


### PR DESCRIPTION
Fix One: URLs in README.md cause warning
-------------------------------------------------

per https://github.com/seattlerb/hoe/pull/104 and https://github.com/seattlerb/hoe/issues/103, remove this warning:

```
jw@logopolis:/projects/open/namecase$ rake
DEPRECATED: Please switch readme to hash format for urls.
  Only defining 'home' url.
  This will be removed on or after 2020-10-28.
Run options: --seed 40480

# Running:

...

Finished in 0.005700s, 526.3000 runs/s, 33156.9001 assertions/s.
3 runs, 189 assertions, 0 failures, 0 errors, 0 skips
```

by also adding URLs to the Rakefile, which has `hoe` settings. So many possible puns but I'm going to pass on them for now.

Fix The Second: Remove bad URL
-----------------------------------------

There is nothing at http://namecase.rubyforge.org/