### PR TITLE
Multibyte first character

### DIFF
--- a/lib/namecase.rb
+++ b/lib/namecase.rb
@@ -31,7 +31,7 @@ module NameCase
 
     localstring = str.downcase
     localstring.gsub!(/\b\p{Word}/) { |first| first.upcase }
-    localstring.gsub!(/\'\w\b/) { |c| c.downcase } # Lowercase 's
+    localstring.gsub!(/\'\p{Word}\b/) { |c| c.downcase } # Lowercase 's
 
     if options[:irish]
       if localstring =~ /\bMac[A-Za-z]{2,}[^aciozj]\b/ or localstring =~ /\bMc/
@@ -60,10 +60,10 @@ module NameCase
 
     if options[:son_or_daughter_of]
       # Fixes for "son (daughter) of" etc
-      localstring.gsub!(/\bAl(?=\s+\w)/, 'al')  # al Arabic or forename Al.
+      localstring.gsub!(/\bAl(?=\s+\p{Word})/, 'al')  # al Arabic or forename Al.
       localstring.gsub!(/\b(Bin|Binti|Binte)\b/,'bin')  # bin, binti, binte Arabic
       localstring.gsub!(/\bAp\b/, 'ap')         # ap Welsh.
-      localstring.gsub!(/\bBen(?=\s+\w)/,'ben') # ben Hebrew or forename Ben.
+      localstring.gsub!(/\bBen(?=\s+\p{Word})/,'ben') # ben Hebrew or forename Ben.
       localstring.gsub!(/\bDell([ae])\b/,'dell\1')  # della and delle Italian.
       localstring.gsub!(/\bD([aeiou'])\b/,'d\1')   # da, de, di Italian; du/d' French; do Brasil
       localstring.gsub!(/\bD([ao]s)\b/,'d\1')   # das, dos Brasileiros
@@ -71,7 +71,7 @@ module NameCase
       localstring.gsub!(/\bEl\b/,'el')   # el Greek or El Spanish.
       localstring.gsub!(/\bLa\b/,'la')   # la French or La Spanish.
       localstring.gsub!(/\bL([eo])\b/,'l\1')      # lo Italian; le French.
-      localstring.gsub!(/\bVan(?=\s+\w)/,'van')  # van German or forename Van.
+      localstring.gsub!(/\bVan(?=\s+\p{Word})/,'van')  # van German or forename Van.
       localstring.gsub!(/\bVon\b/,'von')  # von Dutch/Flemish
     end
 

--- a/lib/namecase.rb
+++ b/lib/namecase.rb
@@ -30,7 +30,7 @@ module NameCase
     end
 
     localstring = str.downcase
-    localstring.gsub!(/\b\w/) { |first| first.upcase }
+    localstring.gsub!(/\b\p{Word}/) { |first| first.upcase }
     localstring.gsub!(/\'\w\b/) { |c| c.downcase } # Lowercase 's
 
     if options[:irish]

--- a/test/test_namecase.rb
+++ b/test/test_namecase.rb
@@ -26,6 +26,9 @@ class TestNameCase < Minitest::Test
       # Roman numerals
       "Henry VIII",       "Louis III",            "Louis XIV",
       "Charles II",       "Fred XLIX",            "Yusof bin Ishak",
+      # Multibyte characters
+      "Iñtërnâtiônàlizætiøn",
+      "Öykü Çelik",
     ]
   end
 
@@ -44,12 +47,6 @@ class TestNameCase < Minitest::Test
       nc_name = NameCase!(name.downcase)
       assert_equal(name, nc_name)
     end
-  end
-
-  def test_namecase_multibyte
-    proper_cased = 'Iñtërnâtiônàlizætiøn'
-    nc_name = NameCase(proper_cased.downcase)
-    assert_equal(proper_cased, nc_name)
   end
 
   def test_that_it_skips_son_or_daughter_of_formatting


### PR DESCRIPTION
## Problem

There are names starting with an Umlaut or some other multibyte character, e.g. Öykü Çelik. Currently they are incorrectly lowercased, because the Regexp for upcasing the first letter only matches `/\b\w/` i.e. `/\b[a-zA-Z0-9_]/`.

```ruby
NameCase("Öykü Çelik", lazy: false) # => "öykü çelik" (expected "Öykü Çelik")
NameCase("Öykü Çelik".downcase) # => "öykü çelik" (expected "Öykü Çelik")
```

## Fix

Use a Regexp based on Unicode properties like  `/\b\p{Word}/`.  With that the tests still pass, including a new test for a name starting with a multibyte character. 

FYI: There are two commits. The first one is the fix itself, in the second commit I've replaced all remaining occurrences of `\w` with `\p{Word}`. If the latter is too much of a change, I can easily undo it.